### PR TITLE
feat: add mass number display to ElementCell component

### DIFF
--- a/src/components/element-cell/index.tsx
+++ b/src/components/element-cell/index.tsx
@@ -38,6 +38,7 @@ export function ElementCell({ element, onSelectElement }: ElementCellProps) {
     >
       <div className="element-info-div">
         <p className="atomic-number">{element.atomicNumber}</p>
+        <p className="mass-number">{Number(element.mass).toFixed(1)}</p>
       </div>
       <div className="element-name-div">
         <p className="element-symbol">{element.symbol}</p>

--- a/src/components/element-cell/style.css
+++ b/src/components/element-cell/style.css
@@ -43,6 +43,17 @@
   font-family: "Oswald";
 }
 
+.mass-number {
+  width: 100%;
+
+  text-align: right;
+
+  font-weight: 300;
+  font-size: 14px;
+  line-height: 1;
+  font-family: "Oswald";
+}
+
 .element-name-div {
   flex-grow: 1;
   width: 100%;


### PR DESCRIPTION
## Objective

- The elements don't show mass number in the periodic table.

## Solution

- Added a new paragraph element in `ElementCell` to display mass number.
- Calculating mass number by rounding mass of element to 1 decimal place.

---

### Testing

- Tested the changes locally on chrome browser.

### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

### Release Notes:

- Display mass number on element cell.