### PR TITLE
fixed `ElementCell` border issue

### DIFF
--- a/src/components/element-cell/style.css
+++ b/src/components/element-cell/style.css
@@ -2,21 +2,26 @@
   cursor: pointer;
   touch-action: manipulation;
 
+  height: var(--element-cell-size);
+  width: var(--element-cell-size);
   aspect-ratio: 1 / 1;
 
   overflow: hidden;
 
+  margin: var(--element-outline-width);
   padding: 5px;
 
-  border-width: 0px;
-  border-style: solid;
-  border-radius: 5px;
-  border-color: var(--primary-cell-color);
+  border: none;
+  border-radius: 6px;
+
+  outline-width: 0px;
+  outline-style: solid;
+  outline-color: var(--primary-cell-color);
 
   background-color: var(--secondary-cell-color);
 
   &:hover {
-    border-width: 1px;
+    outline-width: var(--element-outline-width);
   }
 
   p {

--- a/src/pages/home-page/modern-table/periodic-table/style.css
+++ b/src/pages/home-page/modern-table/periodic-table/style.css
@@ -15,12 +15,13 @@
 
 .table-piece {
   --table-width: calc(
-    (18 * var(--element-cell-size)) + (17 * var(--element-gap))
+    (18 * var(--element-cell-size)) + (17 * var(--element-gap)) +
+      (18 * 2 * var(--element-outline-width))
   );
 
   width: var(--table-width);
 
-  zoom: calc((100vw - 10px) / var(--table-width));
+  zoom: calc((100vw - 2 * var(--table-padding)) / var(--table-width));
 
   display: grid;
   gap: var(--element-gap);

--- a/src/pages/home-page/style.css
+++ b/src/pages/home-page/style.css
@@ -1,4 +1,8 @@
 .element-table {
+  /*
+  Common styles of all element tables.
+  */
+
   --element-size-scale: 1;
   --element-atomic-number-scale: 1;
   --element-symbol-scale: 1;
@@ -6,7 +10,11 @@
 
   --element-cell-size: 70px;
 
+  --element-outline-width: 2px;
+
   --element-gap: 2px;
+
+  --table-padding: 5px;
 
   flex-shrink: 0;
   width: 100%;
@@ -14,12 +22,11 @@
   overflow-y: hidden;
   overflow-x: scroll;
 
-  padding: 5px;
+  padding: var(--table-padding);
 
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 15px;
 
   background-color: var(--absolute-bg);
 }

--- a/src/pages/home-page/triads/style.css
+++ b/src/pages/home-page/triads/style.css
@@ -1,6 +1,4 @@
 #triads-table {
-  --element-cell-gap: 2px;
-
   gap: 20px;
 
   display: grid;
@@ -31,11 +29,10 @@
 
 .triads-group-elements {
   height: fit-content;
-  height: 70px;
   width: fit-content;
 
   display: flex;
-  gap: var(--element-cell-gap);
+  gap: calc(var(--element-gap) + (2 * var(--element-outline-width)));
 
   .element-cell {
     --primary-cell-color: var(--triads-group-color);


### PR DESCRIPTION
## Objective

- Fixes #98 

## Solution

- Instead of applying a border which is calculated in the area provided for the `ElementCell`, Now it applies outline on the cell.

---

### Testing

- Tested changes on local browser.

### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

### Release Notes:

- Fixed the issue when clicking on `ElementCell` displaced internal components.
